### PR TITLE
hack: hardcode v3 api address for twitchemotes

### DIFF
--- a/lib/kappa-slack/uploader.rb
+++ b/lib/kappa-slack/uploader.rb
@@ -94,13 +94,13 @@ module KappaSlack
     end
 
     def twitch_emotes
-      response = JSON.parse(http.get_content('https://twitchemotes.com/api_cache/v2/global.json'))
-      url_template = response['template']['small']
+      response = JSON.parse(http.get_content('https://twitchemotes.com/api_cache/v3/global.json'))
+      url_template = 'https://static-cdn.jtvnw.net/emoticons/v1/{id}/1.0'
 
-      response['emotes'].map do |name, emote|
+      response.map do |name, emote|
         {
           name: name.parameterize,
-          url: url_template.gsub('{image_id}', emote['image_id'].to_s)
+          url: url_template.gsub('{id}', emote['id'].to_s)
         }
       end
     end


### PR DESCRIPTION
Latest commit of `master` doesn't work, twitchemotes responds with v2 api is dead. This makes it work, although if twitchemotes kills v3 api then it'll break again. But I think this is the best that can be done.